### PR TITLE
Update ProducerConfig.java

### DIFF
--- a/src/main/java/io/latent/storm/rabbitmq/config/ProducerConfig.java
+++ b/src/main/java/io/latent/storm/rabbitmq/config/ProducerConfig.java
@@ -74,7 +74,7 @@ public class ProducerConfig implements Serializable
     Map<String, Object> map = new HashMap<String, Object>();
     map.putAll(connectionConfig.asMap());
     addToMap("rabbitmq.exchangeName", map, exchangeName);
-    addToMap("rabbitmq.routingKey", map, routingKey);
+    addToMap("rabbitmq.routingKey", map, routingKey, "");
     addToMap("rabbitmq.contentType", map, contentType);
     addToMap("rabbitmq.contentEncoding", map, contentEncoding);
     addToMap("rabbitmq.persistent", map, persistent);


### PR DESCRIPTION
Provide default empty routing key as parent TupleToMessage does: "rabbitmq java client library treats "" as no routing key"
